### PR TITLE
Fix bugs in index and delete

### DIFF
--- a/src/components/Posts/IndexAllPosts/IndexAllPosts.js
+++ b/src/components/Posts/IndexAllPosts/IndexAllPosts.js
@@ -15,7 +15,7 @@ class PostIndexAll extends Component {
 
     postIndexAll(user)
       .then(res => {
-        console.log('This is res', res)
+        // console.log('This is res', res)
         this.setState({ posts: res.data.post })
       })
       .then(() => msgAlert({
@@ -37,10 +37,9 @@ class PostIndexAll extends Component {
     if (!posts) {
       return 'Loading...'
     }
+    console.log('this is posts in index all', posts)
 
-    const reversedPosts = posts.reverse()
-
-    const postsJsx = reversedPosts.map(post => (
+    const postsJsx = posts.map(post => (
       <Link to={`/posts/${post._id}`} key={post._id}>
         <li>
           {post.title}
@@ -52,7 +51,7 @@ class PostIndexAll extends Component {
       <div>
         <h3>Welcome</h3>
         <ul>
-          {postsJsx}
+          {postsJsx.reverse()}
         </ul>
       </div>
     )

--- a/src/components/Posts/IndexUserPosts/IndexUserPosts.js
+++ b/src/components/Posts/IndexUserPosts/IndexUserPosts.js
@@ -16,7 +16,7 @@ class PostIndexUser extends Component {
     // const ownerId = res.data.post.owner._id
     postIndexUser(user)
       .then(res => {
-        console.log('This is res', res)
+        // console.log('This is res', res)
         this.setState({ posts: res.data.post })
       })
       .then(() => msgAlert({
@@ -50,7 +50,7 @@ class PostIndexUser extends Component {
       <div>
         <h3>Welcome</h3>
         <ul>
-          {postsJsx}
+          {postsJsx.reverse()}
         </ul>
       </div>
     )

--- a/src/components/Posts/ShowPost/ShowPost.js
+++ b/src/components/Posts/ShowPost/ShowPost.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import { Link, withRouter, Redirect } from 'react-router-dom'
+import { Link, withRouter } from 'react-router-dom'
 
 import { showPost, postDelete } from '../../../api/posts'
 
@@ -15,7 +15,7 @@ class PostShow extends Component {
   }
 
   onPostDelete = () => {
-    const { user, match, msgAlert } = this.props
+    const { user, match, history, msgAlert } = this.props
     postDelete(match.params.id, user)
       .then(this.setState({ exists: false }))
       .then(() => msgAlert({
@@ -23,6 +23,7 @@ class PostShow extends Component {
         message: 'The post has been deleted.',
         variant: 'success'
       }))
+      .then(() => history.push('/index'))
       .catch(error => {
         msgAlert({
           heading: 'Deleting Post Failed',
@@ -37,7 +38,7 @@ class PostShow extends Component {
 
     showPost(match.params.id, user)
       .then(res => {
-        console.log('this is res: ', res)
+        // console.log('this is res: ', res)
         this.setState({ post: res.data.post })
         return res
       })
@@ -56,14 +57,14 @@ class PostShow extends Component {
   }
 
   render () {
-    const { post, exists } = this.state
+    const { post } = this.state
     const { user } = this.props
-    console.log('this is user', user)
-    console.log('this is post', post)
+    // console.log('this is user', user)
+    // console.log('this is post', post)
 
-    if (!exists) {
-      return <Redirect to={'/index'} />
-    }
+    // if (!exists) {
+    //   return <Redirect to={'/index'} />
+    // }
 
     if (!post) {
       return 'Loading...'
@@ -80,8 +81,8 @@ class PostShow extends Component {
       showDisplay = (
         <div>
           <h3>{post.title}</h3>
-          <h4>author: {post.author}</h4>
-          <p>{post.content}</p>
+          <h5>Author: {post.author}</h5>
+          <h6>{post.content}</h6>
           <h5>Comments:</h5>
           <ul>
             <li>This will be a comment.</li>
@@ -98,8 +99,8 @@ class PostShow extends Component {
             </Link>
           </button>
           <h3>{post.title}</h3>
-          <h4>author: {post.author}</h4>
-          <p>{post.content}</p>
+          <h5>Author: {post.author}</h5>
+          <h6>{post.content}</h6>
           <h5>Comments:</h5>
           <ul>
             <li>This will be a comment.</li>


### PR DESCRIPTION
- Looked into a problem on index where the reverse would flip back and
forth -> moved the .reverse() down to the return rather than before
the map, this works
- Looked at the problem with delete where it would Redirect the user to
the index; however, the previously deleted post would still be
there. -> commented out the Redirect call at the bottom and rather,
deconstructed history from this.props and then used history.push() to
send the user back to the index after the delete has occurred.

co-authored-by: Pete V. petevallerie@gmail.com
co-authored-by: Faith F. faithfitts@gmail.com
co-authored-by: Nicole S. nicolesurawski@gmail.com